### PR TITLE
Support whitespace options when measuring text

### DIFF
--- a/lib/measure/index.js
+++ b/lib/measure/index.js
@@ -13,7 +13,7 @@ export const getCanvasHandler = doc => {
     if (context && typeof context.measureText === 'function') {
       return (text, font) => {
         context.font = String(font);
-        return context.measureText(text.trim().replace(/\s+/g, ' ')).width;
+        return context.measureText(text).width;
       };
     }
   }
@@ -80,8 +80,8 @@ export const getDumbHandler = warn => {
 const measure = getCanvasHandler(_doc) || getSvgHandler(_doc) || getDumbHandler(_doc);
 
 const wCache = {};
-export default function measureText (token, font, with_shy) {
-  const s = String(token);
+export default function measureText (token, font, with_shy, trim = true, collapse = true) {
+  let s = String(token);
   // empty
   if (!s) {
     return 0;
@@ -95,6 +95,17 @@ export default function measureText (token, font, with_shy) {
     return wCache[cacheId];
   }
   // text
+  if (trim) {
+    s = s.trim();
+  }
+  if (collapse) {
+    s = s.replace(/\s+/g, ' ');
+  }
+  // When there are line breaks in the string but we're either not trimming whitespace or not
+  // collapsing whitespace, do what the input element does and convert all "\n" to " ".
+  if (!trim || !collapse) {
+    s = s.replace(/\n/g, ' ');
+  }
   return measure((with_shy ? s + '-' : s), font) + font.size * (token.tracking || 0);
 }
 

--- a/lib/measure/measure-test.js
+++ b/lib/measure/measure-test.js
@@ -58,3 +58,72 @@ test('measure()', t => {
     45, 'measures given token (with shy)');
   t.end();
 });
+
+test('measure() with whitespace trimming', t => {
+  const token = new String('TEST'); // eslint-disable-line
+  const tokenWithWhitespace = new String('   TEST '); // eslint-disable-line
+  const font = { size: 20, family: 'sans-serif' };
+  t.equal(
+    measure(token, font, false),
+    measure(tokenWithWhitespace, font, false),
+    'measures given token');
+  t.end();
+});
+
+test('measure() without whitespace trimming', t => {
+  const token = new String('TEST'); // eslint-disable-line
+  const tokenWithWhitespace = new String('   TEST '); // eslint-disable-line
+  const font = { size: 20, family: 'sans-serif' };
+  t.ok(
+    measure(token, font, false) <
+      measure(tokenWithWhitespace, font, false, false),
+    'measure can include trailing whitespace'
+  );
+  t.end();
+});
+
+test('measure() without collapsing whitespace', t => {
+  const token = new String('A TEST'); // eslint-disable-line
+  const tokenWithWhitespace = new String('A  TEST'); // eslint-disable-line
+  const font = { size: 20, family: 'sans-serif' };
+  t.ok(
+    measure(token, font, false) <
+      measure(tokenWithWhitespace, font, false, true, false),
+    'measure can leave repeated whitespace alone'
+  );
+  t.end();
+});
+
+test('measure() without collapsing whitespace', t => {
+  const token = new String('A TEST'); // eslint-disable-line
+  const tokenWithWhitespace = new String('A  TEST'); // eslint-disable-line
+  const font = { size: 20, family: 'sans-serif' };
+  t.ok(
+    measure(token, font, false) <
+      measure(tokenWithWhitespace, font, false, true, false),
+    'measure can leave repeated whitespace alone'
+  );
+  t.end();
+});
+
+test('measure() handles newlines when not trimming or collapsing whitespace', t => {
+  const tokenWithWhitespace = new String('A   TEST '); // eslint-disable-line
+  const tokenWithNewLines = new String('A \n TEST\n'); // eslint-disable-line
+  const font = { size: 20, family: 'sans-serif' };
+  t.equal(
+    measure(tokenWithWhitespace, font, false, false, true),
+    measure(tokenWithNewLines, font, false, false, true),
+    'Newlines count as spaces when not trimming whitespace'
+  );
+  t.equal(
+    measure(tokenWithWhitespace, font, false, true, false),
+    measure(tokenWithNewLines, font, false, true, false),
+    'Newlines count as spaces when not collapsing whitespace'
+  );
+  t.equal(
+    measure(tokenWithWhitespace, font, false, false, false),
+    measure(tokenWithNewLines, font, false, false, false),
+    'Newlines count as spaces when neither trimming nor collapsing whitespace'
+  );
+  t.end();
+});


### PR DESCRIPTION
It can be useful to have control over whitespace. At the moment the `measure` function in `lib/measure/index.js` assumes you want "normal" HTML/SVG whitespace handling (like CSS's `white-space: normal`). This PR adds two arguments to the function that allow the caller to control whether the whitespace is trimmed or collapsed. It also makes the three measuring handlers consistent: before now, only the canvas handler trimmed and collapsed whitespace; the SVG and "dumb" handler left the text as-is.

When there are line breaks in the text but we're either not trimming whitespace or not collapsing whitespace, the function does what HTML's input element does and converts all "\n" to " ".

Fixes #23.