### PR TITLE
Use OffscreenCanvas when available

### DIFF
--- a/lib/measure/index.js
+++ b/lib/measure/index.js
@@ -5,7 +5,9 @@ import parseFont from '../font/index.js';
 // Canvas is the prefered way of doing this because
 // it is a clean env, and does not touch the DOM tree
 export const getCanvasHandler = doc => {
-  const canvas = doc && doc.createElement('canvas');
+  const canvas =
+    (typeof OffscreenCanvas !== 'undefined' && new OffscreenCanvas(100, 100)) ||
+    (doc && doc.createElement('canvas'));
   if (canvas && canvas.getContext) {
     const context = canvas.getContext('2d');
     if (context && typeof context.measureText === 'function') {


### PR DESCRIPTION
A [Google Chrome Developers session from 2019](https://youtu.be/ePaUrMCL7g4?t=246) states that `OffscreenCanvas` has better performance than `<canvas>` even when it's running on the main thread. Their benchmarks showed that:

- `OffscreenCanvas` is 50% faster at creation
- Text operations on `OffscreenCanvas` are 15–45% faster.

The second benchmark is of the most value to this library. It's a bit of a micro-optimisation, but it will have benefits if a lot of text measurement is going on.

[`OffscreenCanvas` is available in Chrome and Edge](https://caniuse.com/offscreencanvas) (since 2018 and 2020 respectively). Other browsers will continue to use `<canvas>` to measure text.