### PR TITLE
Support rel and target attrs on SVG <a> elements

### DIFF
--- a/lib/parser/htmlparser-test.js
+++ b/lib/parser/htmlparser-test.js
@@ -27,6 +27,8 @@ function toJSON (t) {
   if (t.family) { r.family = String(t.family); }
   if (t.color) { r.color = String(t.color); }
   if (t.class) { r.class = String(t.class); }
+  if (t.rel) { r.rel = String(t.rel); }
+  if (t.target) { r.target = String(t.target); }
   return r;
 }
 
@@ -340,6 +342,17 @@ test('html parse attributes', t => {
   t.htmlEq(
     '<a href="http://example.com/" style="color: #c05;">colored</a>',
     [ { type: 'TK', val: 'colored', color: '#c05', href: 'http://example.com/' } ]
+  );
+
+  t.htmlEq(
+    '<a href="http://example.com/" rel="noopener noreferrer nofollow" target="_blank">foo</a>',
+    [ { type: 'TK', val: 'foo', href: 'http://example.com/', rel: 'noopener noreferrer nofollow', target: '_blank' } ]
+  );
+
+
+  t.htmlEq(
+    '<span rel="noopener noreferrer nofollow" target="_blank">foo</span>',
+    [ { type: 'TK', val: 'foo' } ]
   );
 
   t.htmlEq(

--- a/lib/parser/htmlparser.js
+++ b/lib/parser/htmlparser.js
@@ -102,7 +102,9 @@ export default function htmlparser (text) {
     sub: false,
     sup: false,
     href: null,
-    color: null
+    color: null,
+    rel: null,
+    target: null
   };
 
   const tokens = [];
@@ -174,8 +176,16 @@ export default function htmlparser (text) {
         tag_to_prop[tagName](prop, '');
       }
       const attr = parseAttr(m[2]);
-      if (tagName === 'a' && attr.href) {
-        prop.href = attr.href;
+      if (tagName === 'a') {
+        if (attr.href) {
+          prop.href = attr.href;
+        }
+        if (attr.rel) {
+          prop.rel = attr.rel;
+        }
+        if (attr.target) {
+          prop.target = attr.target;
+        }
       }
       if (attr.class) {
         prop.class = prop.class ? prop.class + ' ' + attr.class : attr.class;

--- a/lib/svg/render.js
+++ b/lib/svg/render.js
@@ -146,6 +146,8 @@ export default function svgRender (lines, opt) {
             href = token.href;
             segmentType = 'a';
             segmentProps.href = href;
+            segmentProps.rel = token.rel;
+            segmentProps.target = token.target;
           }
           else {
             href = null;


### PR DESCRIPTION
Adds support to the SVG renderer for `target` and `rel` attributes on `<a>` elements. These two attributes are useful for limiting access to `window.opener`, for example, or for opening links in new windows/tabs.

When Textbox's HTML parser is used, any `rel` or `target` attributes on an `<a>` element are included in the rendered SVG. For example:

```js
import Textbox from '@borgar/textbox';
const box = new Textbox({ parser: Textbox.htmlparser });
const line = box.render('<a href="https://example.com/" rel="noopener noreferrer nofollow" target="_blank">Hello world</a>');
```

Will produce:

```html
<text font-family="sans-serif" font-size="12" text-anchor="start">
    <a href="https://example.com/" rel="noopener noreferrer nofollow" target="_blank">
        Hello world
    </a>
</text>
```

These two attributes are only supported on `<a>` elements, and only in the SVG renderer.